### PR TITLE
Grid 4.1

### DIFF
--- a/components/_grid.sass
+++ b/components/_grid.sass
@@ -55,15 +55,17 @@
   #{$g-selector}g-b--#{$namespace}1of1
     width: 100%
 
-  @for $column from 1 to $g-columns
-    @if $column != $g-columns
-      #{$g-selector}g-b--#{$namespace}#{$column}of#{$g-columns}
-        width: percentage($column/$g-columns)
+  @each $g-unit in $g-columns
 
-      @for $division from 1 to $g-columns
-        @if $column % $division == 0 and $g-columns % $division == 0
-          #{$g-selector}g-b--#{$namespace}#{$column / $division}of#{$g-columns / $division}
-            @extend #{$g-selector}g-b--#{$namespace}#{$column}of#{$g-columns}
+    @for $column from 1 to $g-unit
+      @if $column != $g-unit
+        #{$g-selector}g-b--#{$namespace}#{$column}of#{$g-unit}
+          width: percentage($column / $g-unit)
+
+        @for $division from 1 to $g-unit
+          @if $column % $division == 0 and $g-unit % $division == 0
+            #{$g-selector}g-b--#{$namespace}#{$column / $division}of#{$g-unit / $division}
+              @extend #{$g-selector}g-b--#{$namespace}#{$column}of#{$g-unit}
 
 // -------------------------------------
 //   Creation

--- a/components/_grid.sass
+++ b/components/_grid.sass
@@ -55,17 +55,15 @@
   #{$g-selector}g-b--#{$namespace}1of1
     width: 100%
 
-  @each $g-unit in $g-columns
+  @for $unit from 1 to $g-columns + 1
+    @for $column from 1 to $unit
+      #{$g-selector}g-b--#{$namespace}#{$column}of#{$unit}
+        width: percentage($column / $unit)
 
-    @for $column from 1 to $g-unit
-      @if $column != $g-unit
-        #{$g-selector}g-b--#{$namespace}#{$column}of#{$g-unit}
-          width: percentage($column / $g-unit)
-
-        @for $division from 1 to $g-unit
-          @if $column % $division == 0 and $g-unit % $division == 0
-            #{$g-selector}g-b--#{$namespace}#{$column / $division}of#{$g-unit / $division}
-              @extend #{$g-selector}g-b--#{$namespace}#{$column}of#{$g-unit}
+      @for $division from 1 to $unit
+        @if $column % $division == 0 and $unit % $division == 0
+          #{$g-selector}g-b--#{$namespace}#{$column / $division}of#{$unit / $division}
+            @extend #{$g-selector}g-b--#{$namespace}#{$column}of#{$unit}
 
 // -------------------------------------
 //   Creation

--- a/foundation/_config.sass
+++ b/foundation/_config.sass
@@ -92,7 +92,7 @@ $g-l: em(1024px)
 
 // Settings
 
-$g-columns: 10, 12
+$g-columns: 12
 $g-defaults: 's' $g-s, 'm' $g-m, 'l' $g-l
 $g-gutter: $b-space
 $g-silent: false

--- a/foundation/_config.sass
+++ b/foundation/_config.sass
@@ -92,7 +92,7 @@ $g-l: em(1024px)
 
 // Settings
 
-$g-columns: 12
+$g-columns: 10, 12
 $g-defaults: 's' $g-s, 'm' $g-m, 'l' $g-l
 $g-gutter: $b-space
 $g-silent: false


### PR DESCRIPTION
Alternate method of https://github.com/mvcss/mvcss/pull/19 — generates scaffolding for `_grid.sass` up _until_ `$g-columns` is reached. Maintains backwards compatibility.